### PR TITLE
Shooter & feeder velocity control, minor Config changes, rotateToDeg fix

### DIFF
--- a/InfiniteRecharge/src/main/java/frc/robot/config/Config.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/config/Config.java
@@ -1,5 +1,6 @@
 package frc.robot.config;
 
+import frc.robot.config.MotorConfig.EncoderType;
 import frc.robot.utils.control.pidf.PIDF;
 
 public class Config {
@@ -48,6 +49,11 @@ public class Config {
         public MotorConfig leftLeader;
         public MotorConfig rightLeader;
 
+        public boolean isLeftInverted = true;
+        public boolean isRightInverted = false;
+
+        public MotorConfig.EncoderType encoderType = MotorConfig.EncoderType.Quadrature;
+
         public DriveConfig() {
         }
 
@@ -60,9 +66,13 @@ public class Config {
             for (int i = 0; i < MOTORS_PER_SIDE; i++) {
                 leftMotors[i] = new MotorConfig();
                 leftMotors[i].id = leftIDs[i];
+                leftMotors[i].encoderType = encoderType;
+                leftMotors[i].inverted = isLeftInverted;
 
                 rightMotors[i] = new MotorConfig();
                 rightMotors[i].id = rightIDs[i];
+                rightMotors[i].encoderType = encoderType;
+                rightMotors[i].inverted = isRightInverted;
 
                 if (i > 0) {
                     leftMotors[i].followingID = leftIDs[0];

--- a/InfiniteRecharge/src/main/java/frc/robot/config/Config.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/config/Config.java
@@ -49,8 +49,8 @@ public class Config {
         public MotorConfig leftLeader;
         public MotorConfig rightLeader;
 
-        public boolean isLeftInverted = true;
-        public boolean isRightInverted = false;
+        public boolean leftInverted = true;
+        public boolean rightInverted = false;
 
         public MotorConfig.EncoderType encoderType = MotorConfig.EncoderType.Quadrature;
 
@@ -67,12 +67,12 @@ public class Config {
                 leftMotors[i] = new MotorConfig();
                 leftMotors[i].id = leftIDs[i];
                 leftMotors[i].encoderType = encoderType;
-                leftMotors[i].inverted = isLeftInverted;
+                leftMotors[i].inverted = leftInverted;
 
                 rightMotors[i] = new MotorConfig();
                 rightMotors[i].id = rightIDs[i];
                 rightMotors[i].encoderType = encoderType;
-                rightMotors[i].inverted = isRightInverted;
+                rightMotors[i].inverted = rightInverted;
 
                 if (i > 0) {
                     leftMotors[i].followingID = leftIDs[0];

--- a/InfiniteRecharge/src/main/java/frc/robot/config/MotorConfig.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/config/MotorConfig.java
@@ -6,6 +6,28 @@ public class MotorConfig {
 
     //////////////////////////////////////////////////////////////////////////////
     // Other
+    public enum EncoderType {
+        // Again, you already know what this one does, I'm just writing this so that
+        // VSCode doesn't mess up my format.
+        None,
+
+        // Starts at 0, increments ticks based on how much they rotated.
+        Quadrature,
+
+        // Effectively the same thing as quadrature, there might be a few differences,
+        // but I can't think of any.
+        Relative,
+
+        // Whereas relative and quadrature determine their position by the amount they
+        // have rotated, absolute determines where it is based on the angle of the
+        // motor.
+        Absolute,
+
+        // Uses the internal sensor if the motor has one.
+        Integrated
+    }
+
+    public EncoderType encoderType = EncoderType.Quadrature;
 
     public int ticksPerRevolution;
 

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/drive/DriveSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/drive/DriveSubsystem.java
@@ -106,21 +106,12 @@ public class DriveSubsystem extends BitBucketSubsystem {
             rightMotors[i].setStatusFramePeriod(StatusFrameEnhanced.Status_13_Base_PIDF0, 
 											DriveConstants.HIGH_STATUS_FRAME_PERIOD_MS, 
                                             DriveConstants.CONTROLLER_TIMEOUT_MS);
-            
-            MotorUtils.initializeQuadEncoderMotor(leftMotors[i]);
-            MotorUtils.initializeQuadEncoderMotor(rightMotors[i]);
-
         }
 
         leftMotors[0].setSensorPhase(DriveConstants.LEFT_DRIVE_MOTOR_SENSOR_PHASE);
         rightMotors[0].setSensorPhase(DriveConstants.RIGHT_DRIVE_MOTOR_SENSOR_PHASE);
         leftMotors[0].selectProfileSlot(MotorUtils.velocitySlot, 0);
         rightMotors[0].selectProfileSlot(MotorUtils.velocitySlot, 0);
-
-
-        leftMotors[0].setInverted(true);
-        leftMotors[1].setInverted(true);
-
 
 
         setDefaultCommand(new Idle(this));

--- a/InfiniteRecharge/src/main/java/frc/robot/utils/talonutils/MotorUtils.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/utils/talonutils/MotorUtils.java
@@ -138,6 +138,32 @@ public class MotorUtils {
         motor.config_IntegralZone(velocitySlot, (int) motorConfig.velocityPIDF.getIZone());
         motor.setSensorPhase(motorConfig.sensorPhase);
         motor.setInverted(motorConfig.inverted);
+
+        switch (motorConfig.encoderType) {
+        case None:
+            motor.configSelectedFeedbackSensor(FeedbackDevice.None);
+            break;
+
+        case Quadrature:
+            motor.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder);
+            motor.setSelectedSensorPosition(0);
+            break;
+
+        case Relative:
+            motor.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative);
+            motor.setSelectedSensorPosition(0);
+            break;
+
+        case Absolute:
+            motor.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Absolute);
+            break;
+
+        case Integrated:
+            motor.configSelectedFeedbackSensor(FeedbackDevice.IntegratedSensor);
+            motor.setSelectedSensorPosition(0);
+            break;
+        }
+
         if (motorConfig.followingID != -1) {
             motor.set(ControlMode.Follower, motorConfig.followingID);
         }
@@ -146,10 +172,8 @@ public class MotorUtils {
 
     public static void motorInit(CANSparkMax motor, MotorConfig motorConfig) {
         /* Configure Sensor Source for velocity PID */
-        CANEncoder encoder = motor.getEncoder(EncoderType.kQuadrature, 8192);
+        CANEncoder encoder;
 
-        /* Zero the sensor */
-        encoder.setPosition(0);
         // brushless motors can't be inverted
         // encoder.setInverted(settings.sensorPhase);
 
@@ -170,6 +194,29 @@ public class MotorUtils {
         pidController.setD(motorConfig.velocityPIDF.getKI(), velocitySlot);
         pidController.setIZone(motorConfig.velocityPIDF.getIZone(), velocitySlot);
         motor.setInverted(motorConfig.inverted);
+        switch (motorConfig.encoderType) {
+        case Quadrature:
+            encoder = motor.getEncoder(EncoderType.kQuadrature, 8192);
+            break;
+
+        case Relative:
+            encoder = motor.getEncoder(EncoderType.kQuadrature, 8192);
+            break;
+
+        case Absolute:
+            throw new RuntimeException("You used an absolute encoder type for a CAN Spark! You ABSOLUTE fool!");
+
+        case Integrated:
+            encoder = motor.getEncoder();
+            break;
+        case None:
+        default:
+            encoder = motor.getEncoder(EncoderType.kNoSensor, 8192);
+            break;
+
+        }
+        /* Zero the sensor */
+        encoder.setPosition(0);
     }
 
     public static WPI_TalonSRX makeSRX(MotorConfig motorConfig) {


### PR DESCRIPTION
-Added a velocity control mode to the feeder and shooter, fire using velocity control with L1 and R1.

-Changed the drive motor IDs back to arrays in the config.

-Added a shooterGearRatio to the config.

-Renamed config.shooter.gearRatio to config.shooter.azimuthGearRatio

-rotateToDeg now uses the gear ratio of the azimuth.