### PR TITLE
Robot disabling and zeroing the elevation sensor

### DIFF
--- a/InfiniteRecharge/src/main/java/frc/robot/Robot.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/Robot.java
@@ -145,8 +145,6 @@ public class Robot extends TimedRobot {
 
     @Override
     public void teleopInit() {
-        // TODO Auto-generated method stub
-        super.teleopInit();
     }
 
     /**
@@ -252,8 +250,6 @@ public class Robot extends TimedRobot {
 
     @Override
     public void disabledInit() {
-        // TODO Auto-generated method stub
-        super.disabledInit();
         for (BitBucketSubsystem subsystem : subsystems) {
             subsystem.disable();
         }

--- a/InfiniteRecharge/src/main/java/frc/robot/Robot.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/Robot.java
@@ -84,7 +84,9 @@ public class Robot extends TimedRobot {
             subsystems.add(spinnyBoiSubsystem);
         }
 
-        subsystems.add(new PIDHelperSubsystem(config));
+        if (config.enablePIDHelper) {
+            subsystems.add(new PIDHelperSubsystem(config));
+        }
 
         for (BitBucketSubsystem subsystem : subsystems) {
             subsystem.initialize();
@@ -132,7 +134,6 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void autonomousInit() {
-        shooterSubsystem.zeroElevationSensor();
     }
 
     /**
@@ -146,7 +147,6 @@ public class Robot extends TimedRobot {
     public void teleopInit() {
         // TODO Auto-generated method stub
         super.teleopInit();
-        shooterSubsystem.zeroElevationSensor();
     }
 
     /**
@@ -226,8 +226,9 @@ public class Robot extends TimedRobot {
                 shooterSubsystem.resetPositionElevationSwitcher();
             }
 
-            if (oi.setElevationToDashboardNumber()){
-                shooterSubsystem.rotateToDeg(shooterSubsystem.getTargetAzimuthDeg(), SmartDashboard.getNumber(shooterSubsystem.getName() + "/Dashboard Elevation Target", 10));
+            if (oi.setElevationToDashboardNumber()) {
+                shooterSubsystem.rotateToDeg(shooterSubsystem.getTargetAzimuthDeg(),
+                        SmartDashboard.getNumber(shooterSubsystem.getName() + "/Dashboard Elevation Target", 10));
             }
         }
     }
@@ -255,7 +256,7 @@ public class Robot extends TimedRobot {
         super.disabledInit();
         for (BitBucketSubsystem subsystem : subsystems) {
             subsystem.disable();
-        }    
+        }
     }
 
     // COMMANDS the robot to WIN!

--- a/InfiniteRecharge/src/main/java/frc/robot/Robot.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/Robot.java
@@ -132,6 +132,7 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void autonomousInit() {
+        shooterSubsystem.zeroElevationSensor();
     }
 
     /**
@@ -139,6 +140,13 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void autonomousPeriodic() {
+    }
+
+    @Override
+    public void teleopInit() {
+        // TODO Auto-generated method stub
+        super.teleopInit();
+        shooterSubsystem.zeroElevationSensor();
     }
 
     /**
@@ -239,6 +247,15 @@ public class Robot extends TimedRobot {
         for (BitBucketSubsystem subsystem : subsystems) {
             subsystem.testPeriodic();
         }
+    }
+
+    @Override
+    public void disabledInit() {
+        // TODO Auto-generated method stub
+        super.disabledInit();
+        for (BitBucketSubsystem subsystem : subsystems) {
+            subsystem.disable();
+        }    
     }
 
     // COMMANDS the robot to WIN!

--- a/InfiniteRecharge/src/main/java/frc/robot/config/Config.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/config/Config.java
@@ -15,6 +15,7 @@ public class Config {
     public boolean enableClimbSubsystem = true;
     public boolean enableIntakeSubsystem = true;
     public boolean enableSpinnyboiSubsystem = true;
+    public boolean enablePIDHelper = false;
 
     //////////////////////////////////////////////////////////////////////////////
     // Motor IDs

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/BitBucketSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/BitBucketSubsystem.java
@@ -105,4 +105,6 @@ public abstract class BitBucketSubsystem extends SubsystemBase {
     public abstract void periodic(float deltaTime);
 
     public abstract void dashboardPeriodic(float deltaTime);
+
+    public abstract void disable();
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/climber/ClimbSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/climber/ClimbSubsystem.java
@@ -36,4 +36,7 @@ public class ClimbSubsystem extends BitBucketSubsystem {
         // TODO Auto-generated method stub
 
     }
+
+    public void disable(){
+    }
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/copypaste/TestSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/copypaste/TestSubsystem.java
@@ -41,4 +41,7 @@ public class TestSubsystem extends BitBucketSubsystem {
 
     }
 
+    public void disable(){
+    }
+
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/navigation/NavigationSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/navigation/NavigationSubsystem.java
@@ -222,4 +222,7 @@ public class NavigationSubsystem extends BitBucketSubsystem {
         // TODO Auto-generated method stub
 
     }
+
+    public void disable(){
+    }
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/pidhelper/PIDHelperSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/pidhelper/PIDHelperSubsystem.java
@@ -302,4 +302,7 @@ public class PIDHelperSubsystem extends BitBucketSubsystem {
 
         return chooser;
     }
+
+    public void disable(){
+    }
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/intake/IntakeSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/intake/IntakeSubsystem.java
@@ -119,4 +119,8 @@ public class IntakeSubsystem extends BitBucketSubsystem {
         SmartDashboard.putNumber(getName() + "/IntakeOut", motor.getMotorOutputPercent());
     }
 
+    public void disable(){
+        motor.set(0);
+    }
+
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ShooterSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ShooterSubsystem.java
@@ -457,4 +457,24 @@ public class ShooterSubsystem extends BitBucketSubsystem {
         
         SmartDashboard.putNumber(getName() + "/Falcon temperature", (32 + 1.8*ballPropulsionMotor.getTemperature()));
     }
+    public void disable(){
+        azimuthMotor.set(0);
+        elevationMotor.set(0);
+        ballPropulsionMotor.set(0);
+        feeder.set(0);
+
+        upToSpeed = false;
+        positionElevationSwitcherAlreadyPressed = false;
+
+        targetPositionAzimuth_ticks = 0;
+        targetChangeAzimuth_ticks = 0;
+        targetPositionElevation_ticks = 0;
+        targetChangeElevation_ticks = 0;
+        absoluteDegreesToRotateAzimuth = 0;
+        absoluteDegreesElevation = 0;
+    }
+
+    public void zeroElevationSensor(){
+        elevationMotor.setSelectedSensorPosition(0);
+    }
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ball_management/BallManagementSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ball_management/BallManagementSubsystem.java
@@ -56,7 +56,7 @@ public class BallManagementSubsystem extends BitBucketSubsystem {
     @Override
     public void periodic(float deltaTime) {
         // TODO Auto-generated method stub
-        deltaTimeBMS = deltaTime;
+        // deltaTimeBMS = deltaTime;
     }
 
     /**
@@ -65,19 +65,19 @@ public class BallManagementSubsystem extends BitBucketSubsystem {
      */
     public void fire(float rate) {
 
-        timer = timer + deltaTimeBMS;
+        // timer = timer + deltaTimeBMS;
         
         // Because you can neva 'ave enuf dakka!
         SmartDashboard.putString(getName() + "/State",
                 "DAKKADAKKADAKKADAKKADAKKDAKKADAKKADAKKADAKKADAKKADAKKADAKKDAKKADAKKADAKKADAKKADAKKADAKKADAKKDAKKADAKKADAKKADAKKADAKKADAKKADAKKDAKKADAKKA");
-        if (timer <= 0.5) {
+        // if (timer <= 0.5) {
             motor.set(ControlMode.PercentOutput, rate);
-        } else {
-            motor.set(ControlMode.PercentOutput, 0);
-        }
-        if (timer >= 1) {
-            timer = 0;
-        }
+        // } else {
+        //     motor.set(ControlMode.PercentOutput, 0);
+        // }
+        // if (timer >= 1) {
+        //     timer = 0;
+        // }
     }
 
     public void doNotFire() {

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ball_management/BallManagementSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ball_management/BallManagementSubsystem.java
@@ -91,4 +91,8 @@ public class BallManagementSubsystem extends BitBucketSubsystem {
         // TODO Auto-generated method stub
 
     }
+
+    public void disable(){
+        motor.set(0);
+    }
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/spinnyboi/SpinnyBoiSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/spinnyboi/SpinnyBoiSubsystem.java
@@ -54,4 +54,8 @@ public class SpinnyBoiSubsystem extends BitBucketSubsystem {
 
     }
 
+    public void disable(){
+        motor.set(0);
+    }
+
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/vision/VisionSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/vision/VisionSubsystem.java
@@ -140,4 +140,7 @@ public class VisionSubsystem extends BitBucketSubsystem {
 
     }
 
+    public void disable(){
+    }
+
 }


### PR DESCRIPTION
-Added the disable method to every subsystem.
It is called when the robot is disabled.

-The shooter, intake, ball management, and spinnyboi subsystems all now utilize this method to turn off all of their motors.

-Added the zeroElevationSensor method to the shooter subsystem, which does what it's name suggests and is called during teleop and autonomous init.

-Disabled BMS motor oscillation.