### PR TITLE
Limit switch fix and bang bang efficiency

### DIFF
--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ShooterConstants.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ShooterConstants.java
@@ -16,4 +16,5 @@ public class ShooterConstants {
     public static final double BANG_BANG_PERCENT = 1.0;
     public static final double BANG_BANG_RAMP_UP_PERCENT = 0.5;
     public static final int BANG_BANG_ERROR = 0;
+    public static final double BANG_BANG_MAINTAIN_SPEED_PERCENT = 0.6;
 }

--- a/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ShooterSubsystem.java
+++ b/InfiniteRecharge/src/main/java/frc/robot/subsystem/scoring/shooter/ShooterSubsystem.java
@@ -185,7 +185,6 @@ public class ShooterSubsystem extends BitBucketSubsystem {
 
         if (elevationMotor.getSensorCollection().isRevLimitSwitchClosed()){
             elevationMotor.setSelectedSensorPosition(0);
-            targetPositionElevation_ticks = 0;
         }
 
         azimuthMotor.set(ControlMode.MotionMagic, targetPositionAzimuth_ticks);
@@ -502,6 +501,8 @@ public class ShooterSubsystem extends BitBucketSubsystem {
                 // However if our error is 300, 300 is definitely MORE than -150,
                 // so it will continue on to the other if statements.
 
+            } else if (error < 0 && error > -tp100ms / 8) {
+                ballPropulsionMotor.set(ControlMode.PercentOutput, ShooterConstants.BANG_BANG_MAINTAIN_SPEED_PERCENT);
             } else if (error < ShooterConstants.BANG_BANG_ERROR) {
                 ballPropulsionMotor.set(ControlMode.PercentOutput, ShooterConstants.BANG_BANG_PERCENT);
             } else {


### PR DESCRIPTION
-Bang bang control for the shooter now reduces it's output to maintain speed, rather than setting it to 100%.

-The elevation limit switch no longer sets it's target position to 0.